### PR TITLE
UI tweaks for parent and child views

### DIFF
--- a/src/components/AddQuest.js
+++ b/src/components/AddQuest.js
@@ -6,7 +6,7 @@ import { Form, Button } from "react-bootstrap";
 
 export default function AddQuest({ selectedChild }) {
   const [title, setTitle] = useState("");
-  const [points, setPoints] = useState(0);
+  const [points, setPoints] = useState("");
   const [photo, setPhoto] = useState(null);
 
   const handleAdd = async (e) => {
@@ -40,7 +40,7 @@ export default function AddQuest({ selectedChild }) {
     });
 
     setTitle("");
-    setPoints(0);
+    setPoints("");
     setPhoto(null);
     alert("퀘스트가 생성되었습니다!");
   };
@@ -57,7 +57,7 @@ export default function AddQuest({ selectedChild }) {
       <Form.Control
         type="number"
         className="mb-2"
-        placeholder="포인트"
+        placeholder="원하시는 포인트 점수를 적어주세요"
         value={points}
         onChange={(e) => setPoints(e.target.value)}
       />

--- a/src/components/AfterSchoolSchedule.js
+++ b/src/components/AfterSchoolSchedule.js
@@ -24,7 +24,7 @@ export default function AfterSchoolSchedule() {
             <th></th>
             {days.map((d) => (
               <th key={d} className={d === today ? "today-col" : ""}>
-                {d}요일
+                {d}
               </th>
             ))}
           </tr>

--- a/src/components/ChildDashboard.js
+++ b/src/components/ChildDashboard.js
@@ -9,6 +9,7 @@ import RoutineList from "./RoutineList";
 import PurchaseMarket from "./PurchaseMarket";
 import ChildPoints from "./ChildPoints";
 import AfterSchoolSchedule from "./AfterSchoolSchedule";
+import "../styles/PurchaseMarket.css";
 
 export default function ChildDashboard() {
   /* ──────────────── 상태 ──────────────── */
@@ -16,6 +17,7 @@ export default function ChildDashboard() {
   const [myName, setMyName] = useState("");
   const [reqExists, setReqExists] = useState(false);
   const [showMarket, setShowMarket] = useState(false); // 마켓 뷰 토글
+  const [invOpen, setInvOpen] = useState(false); // 인벤토리 토글
 
   /* ──────────────── 초기 데이터 로드 ──────────────── */
   useEffect(() => {
@@ -101,22 +103,20 @@ export default function ChildDashboard() {
             mountOnEnter
             unmountOnExit
           >
-            {/* 뒤로가기 버튼 */}
-            <Button
-              variant="warning"
-              className="w-100 py-2 mb-3 d-flex align-items-center
-                       justify-content-center gap-2 fw-semibold"
-              style={{
-                borderRadius: "0.75rem",
-                boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-              }}
-              onClick={() => setShowMarket(false)}
-            >
-              <span style={{ fontSize: "1.25rem" }}>←</span>
-              퀘스트로 돌아가기
-            </Button>
+            <div className="mb-3">
+              <Button
+                variant="warning"
+                className="inventory-toggle w-100"
+                onClick={() => setInvOpen(!invOpen)}
+              >
+                <span role="img" aria-label="chest" className="me-1">
+                  📦
+                </span>
+                {invOpen ? "인벤토리 접기" : "인벤토리 펼치기"}
+              </Button>
+            </div>
 
-            <PurchaseMarket />
+            <PurchaseMarket invOpen={invOpen} setInvOpen={setInvOpen} />
           </Tab>
         </Tabs>
 

--- a/src/components/PurchaseMarket.js
+++ b/src/components/PurchaseMarket.js
@@ -17,7 +17,7 @@ import {
 import { Card, Button, Spinner, Form, Collapse, Modal } from "react-bootstrap"; // 🔸 Modal 추가
 import "../styles/PurchaseMarket.css";
 
-export default function PurchaseMarket() {
+export default function PurchaseMarket({ invOpen, setInvOpen }) {
   /* ───────── 상태 ───────── */
   const [inventory, setInventory] = useState([]);
   const [market, setMarket] = useState([]);
@@ -25,7 +25,6 @@ export default function PurchaseMarket() {
   const [selectedParent, setSelectedParent] = useState({}); // txId → parentUid
 
   const [loading, setLoading] = useState(true);
-  const [invOpen, setInvOpen] = useState(false);
 
   /* 🔸 모달용 상태 */
   const [parentModal, setParentModal] = useState(false); // 모달 on/off
@@ -153,18 +152,6 @@ export default function PurchaseMarket() {
   /* ───────── 뷰 ───────── */
   return (
     <>
-      {/* ▣ 인벤토리 토글 ▣ */}
-      <Button
-        variant="warning"
-        className="inventory-toggle mb-3"
-        onClick={() => setInvOpen(!invOpen)}
-      >
-        <span role="img" aria-label="chest" className="me-1">
-          📦
-        </span>
-        {invOpen ? "인벤토리 접기" : "내 인벤토리 펼치기"}
-      </Button>
-
       {/* ▣ 인벤토리 리스트 ▣ */}
       <Collapse in={invOpen}>
         <div className="inventory-list mb-4">
@@ -225,7 +212,7 @@ export default function PurchaseMarket() {
 
       {/* ▣ 패밀리마켓 ▣ */}
       <h5
-        className="mb-3"
+        className="mb-3 text-center"
         style={{
           color: "#A8FF60" /* 글자색 */,
           fontSize: "2rem" /* 폰트 크기 */,

--- a/src/components/RoutineList.js
+++ b/src/components/RoutineList.js
@@ -120,8 +120,6 @@ export default function RoutineList({ session }) {
   // 4) 단계 토글 핸들러
   const toggleStep = async (idx) => {
     if (!uid) return;
-    // 선행 단계가 완료되지 않으면 중지
-    if (idx > 1 && !steps[idx - 1]) return;
 
     // 새 상태 복제
     const updated = { ...steps, awardedSteps: [...steps.awardedSteps] };
@@ -169,19 +167,13 @@ export default function RoutineList({ session }) {
             key={i}
             action
             onClick={() => toggleStep(i + 1)}
-            disabled={i > 0 && !steps[i]}
             className="d-flex align-items-center"
-            style={{
-              cursor: i === 0 || steps[i] ? "pointer" : "not-allowed",
-              opacity: i === 0 || steps[i] ? 1 : 0.5,
-            }}
           >
             <Form.Check
               type="checkbox"
               checked={steps[i + 1]}
               onChange={() => toggleStep(i + 1)}
               className="me-2"
-              disabled={i > 0 && !steps[i]}
             />
             <span
               style={{

--- a/src/components/SignUp.js
+++ b/src/components/SignUp.js
@@ -1,9 +1,16 @@
 // src/components/SignUp.js
 import React, { useState } from "react";
-import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
+import {
+  createUserWithEmailAndPassword,
+  updateProfile,
+  GoogleAuthProvider,
+  signInWithPopup,
+} from "firebase/auth";
 import { setDoc, doc } from "firebase/firestore";
 import { auth, db } from "../firebase";
 import { Form, Button, Card } from "react-bootstrap";
+
+const provider = new GoogleAuthProvider();
 
 export default function SignUp({ goLogin }) {
   const [name, setName] = useState("");
@@ -30,6 +37,24 @@ export default function SignUp({ goLogin }) {
       });
 
       // 알림 없이 바로 로그인 화면으로 이동
+      goLogin();
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
+  const handleGoogle = async () => {
+    try {
+      const cred = await signInWithPopup(auth, provider);
+      await setDoc(
+        doc(db, "users", cred.user.uid),
+        {
+          name: cred.user.displayName ?? "",
+          email: cred.user.email,
+          role: "select",
+        },
+        { merge: true }
+      );
       goLogin();
     } catch (err) {
       alert(err.message);
@@ -67,8 +92,15 @@ export default function SignUp({ goLogin }) {
           value={pw2}
           onChange={(e) => setPw2(e.target.value)}
         />
-        <Button type="submit" className="w-100">
-          가입하기
+        <Button type="submit" className="w-100 mb-2">
+          이메일로 가입하기
+        </Button>
+        <Button
+          variant="outline-secondary"
+          className="w-100 mb-2"
+          onClick={handleGoogle}
+        >
+          Google 계정으로 가입하기
         </Button>
         <Button variant="link" className="w-100 mt-2" onClick={goLogin}>
           이미 계정이 있나요? 로그인

--- a/src/styles/AfterSchool.css
+++ b/src/styles/AfterSchool.css
@@ -5,6 +5,8 @@
 .after-school td {
   padding: 1rem;
   font-size: 1.25rem;
+  max-width: 4ch;
+  word-break: break-all;
 }
 .after-school .time-col {
   background: var(--bg-main);
@@ -12,6 +14,6 @@
   font-weight: 600;
 }
 .after-school .today-col {
-  background: #ffd1d1;
-  color: inherit;
+  background: #FF3B30;
+  color: #fff;
 }

--- a/src/styles/PurchaseMarket.css
+++ b/src/styles/PurchaseMarket.css
@@ -5,15 +5,10 @@
 /* ========== 1. 공통 레이아웃 ========== */
 .market-grid {
   display: grid;
-
-  /* 열(트랙) 규칙
-     - 최소 140 px 보다 작아지지 않고
-     - 남는 공간이 있으면 모든 열이 똑같이 넓어지며
-     - 뷰포트가 좁아지면 열 개수가 자동 감소 */
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.6rem;
-  justify-content: center;   /* 마지막 줄을 가운데 정렬 */
+  justify-items: center;
+  justify-content: center;
 }
 
 /* 카드 자체 넓이가 늘어나다 못해 너무 커지는 게 싫다면 +α */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -95,19 +95,6 @@ hr                 { border-top:1px solid var(--bg-hover); }
 
 #market-tab {background-color: #ffffff;}
 
-/* 네 번째 <div> 안에 있는 첫 번째 버튼 */
-div:nth-of-type(4) > div > button:nth-of-type(1) {
-  background: #ffffff !important;   /* 흰 배경 */
-  color: #000;                      /* 글씨색(필요하면) */
-  border-color: transparent;        /* 테두리 제거(선택) */
-}
-
-/* 네 번째 <div> 안에 있는 두 번째 버튼 */
-div:nth-of-type(4) > div > button:nth-of-type(2) {
-  background: #ffffff !important;
-  color: #000;
-  border-color: transparent;
-}
 
 /* 포인트 마켓( single-tab )이 선택된 상태 → 빨간 배경 */
 .single-tab .nav-link.active {


### PR DESCRIPTION
## Summary
- refine point market inventory toggle text and remove close button
- allow parent to toggle routine steps with confirmation
- enable Google sign-up alongside email sign-up
- highlight today's after-school column in red

## Testing
- `npm test` *(fails: react-scripts not found)*