### PR TITLE
UI tweaks for parent and child views

### DIFF
--- a/src/components/AddQuest.js
+++ b/src/components/AddQuest.js
@@ -6,7 +6,7 @@ import { Form, Button } from "react-bootstrap";
 
 export default function AddQuest({ selectedChild }) {
   const [title, setTitle] = useState("");
-  const [points, setPoints] = useState(0);
+  const [points, setPoints] = useState("");
   const [photo, setPhoto] = useState(null);
 
   const handleAdd = async (e) => {
@@ -40,7 +40,7 @@ export default function AddQuest({ selectedChild }) {
     });
 
     setTitle("");
-    setPoints(0);
+    setPoints("");
     setPhoto(null);
     alert("퀘스트가 생성되었습니다!");
   };
@@ -57,7 +57,7 @@ export default function AddQuest({ selectedChild }) {
       <Form.Control
         type="number"
         className="mb-2"
-        placeholder="포인트"
+        placeholder="원하시는 포인트 점수를 적어주세요"
         value={points}
         onChange={(e) => setPoints(e.target.value)}
       />

--- a/src/components/AfterSchoolAdmin.js
+++ b/src/components/AfterSchoolAdmin.js
@@ -1,74 +1,134 @@
 import React, { useEffect, useState } from "react";
 import { db } from "../firebase";
-import { doc, getDoc } from "firebase/firestore";
-import { Table, Spinner } from "react-bootstrap";
+import { doc, getDoc, setDoc } from "firebase/firestore";
+import { Table, Spinner, Modal, Button, Form } from "react-bootstrap";
 import "../styles/AfterSchool.css";
 
-const TIMES = ["1~2", "2~3", "3~4", "4~5", "6~7", "7~8"];
-const DEFAULT_SCHEDULE = {
-  mon: ["국어", "", "", "", "", ""],
-  tue: ["수학", "", "", "", "", ""],
-  wed: ["축구", "", "", "", "", ""],
-  thu: ["음악", "", "", "", "", ""],
-  fri: ["독서", "", "", "", "", ""],
+const TIMES = ["1시", "2시", "3시", "4시", "5시", "6시", "7시"];
+const DAYS = [
+  { key: "mon", label: "월" },
+  { key: "tue", label: "화" },
+  { key: "wed", label: "수" },
+  { key: "thu", label: "목" },
+  { key: "fri", label: "금" },
+];
+
+const createDefault = () => {
+  const obj = {};
+  DAYS.forEach((d) => {
+    obj[d.key] = {};
+    TIMES.forEach((t) => {
+      obj[d.key][t] = { text: "", highlight: false };
+    });
+  });
+  return obj;
 };
 
-export default function AfterSchoolSchedule() {
-  const [schedule, setSchedule] = useState(DEFAULT_SCHEDULE);
+export default function AfterSchoolAdmin() {
+  const [schedule, setSchedule] = useState(createDefault());
   const [loading, setLoading] = useState(true);
+  const [edit, setEdit] = useState(null); // {day, time, text, highlight}
+
+  const docRef = doc(db, "afterSchool", "schedule");
 
   useEffect(() => {
-    let isMounted = true;
+    let mounted = true;
     (async () => {
       try {
-        const snap = await getDoc(doc(db, "afterSchool", "schedule"));
+        const snap = await getDoc(docRef);
         if (snap.exists()) {
           const data = snap.data();
-          if (isMounted) setSchedule({ ...DEFAULT_SCHEDULE, ...data });
+          if (mounted) setSchedule({ ...createDefault(), ...data });
         }
       } catch (e) {
         console.error("afterSchool load", e);
       } finally {
-        if (isMounted) setLoading(false);
+        if (mounted) setLoading(false);
       }
     })();
     return () => {
-      isMounted = false;
+      mounted = false;
     };
   }, []);
 
-  if (loading) return <Spinner animation="border" />;
+  const openEdit = (day, time) => {
+    const cell = schedule[day][time] || { text: "", highlight: false };
+    setEdit({ day, time, text: cell.text, highlight: cell.highlight });
+  };
 
-  const days = [
-    { key: "mon", label: "월" },
-    { key: "tue", label: "화" },
-    { key: "wed", label: "수" },
-    { key: "thu", label: "목" },
-    { key: "fri", label: "금" },
-  ];
+  const saveEdit = async () => {
+    const updated = { ...schedule };
+    updated[edit.day][edit.time] = {
+      text: edit.text,
+      highlight: edit.highlight,
+    };
+    setSchedule(updated);
+    await setDoc(docRef, updated, { merge: true });
+    setEdit(null);
+  };
+
+  if (loading) return <Spinner animation="border" />;
 
   return (
     <div className="after-school">
-      <Table bordered className="text-center fs-5">
+      <Table bordered className="text-center fs-5 after-school-table">
         <thead>
           <tr>
-            <th>요일</th>
-            {TIMES.map((t) => (
-              <th key={t}>{t}</th>
+            <th></th>
+            {DAYS.map((d) => (
+              <th key={d.key}>{d.label}</th>
             ))}
           </tr>
         </thead>
         <tbody>
-          {days.map((d) => (
-            <tr key={d.key}>
-              <th>{d.label}</th>
-              {TIMES.map((_, idx) => (
-                <td key={idx}>{schedule[d.key][idx] || ""}</td>
-              ))}
+          {TIMES.map((t) => (
+            <tr key={t}>
+              <td className="time-col">{t}</td>
+              {DAYS.map((d) => {
+                const cell = schedule[d.key][t] || {};
+                const cls = cell.highlight ? "highlight-cell" : "";
+                return (
+                  <td
+                    key={d.key}
+                    className={cls}
+                    onClick={() => openEdit(d.key, t)}
+                  >
+                    {cell.text}
+                  </td>
+                );
+              })}
             </tr>
           ))}
         </tbody>
       </Table>
+
+      {edit && (
+        <Modal show onHide={() => setEdit(null)}>
+          <Modal.Header closeButton>
+            <Modal.Title>내용 수정</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Form.Control
+              className="mb-2"
+              placeholder="내용 입력"
+              value={edit.text}
+              onChange={(e) => setEdit({ ...edit, text: e.target.value })}
+            />
+            <Form.Check
+              type="checkbox"
+              label="강조하기"
+              checked={edit.highlight}
+              onChange={(e) => setEdit({ ...edit, highlight: e.target.checked })}
+            />
+          </Modal.Body>
+          <Modal.Footer>
+            <Button variant="secondary" onClick={() => setEdit(null)}>
+              취소
+            </Button>
+            <Button onClick={saveEdit}>확인</Button>
+          </Modal.Footer>
+        </Modal>
+      )}
     </div>
   );
 }

--- a/src/components/ChildDashboard.js
+++ b/src/components/ChildDashboard.js
@@ -9,6 +9,7 @@ import RoutineList from "./RoutineList";
 import PurchaseMarket from "./PurchaseMarket";
 import ChildPoints from "./ChildPoints";
 import AfterSchoolSchedule from "./AfterSchoolSchedule";
+import "../styles/PurchaseMarket.css";
 
 export default function ChildDashboard() {
   /* ──────────────── 상태 ──────────────── */
@@ -16,6 +17,7 @@ export default function ChildDashboard() {
   const [myName, setMyName] = useState("");
   const [reqExists, setReqExists] = useState(false);
   const [showMarket, setShowMarket] = useState(false); // 마켓 뷰 토글
+  const [invOpen, setInvOpen] = useState(false); // 인벤토리 토글
 
   /* ──────────────── 초기 데이터 로드 ──────────────── */
   useEffect(() => {
@@ -101,22 +103,27 @@ export default function ChildDashboard() {
             mountOnEnter
             unmountOnExit
           >
-            {/* 뒤로가기 버튼 */}
-            <Button
-              variant="warning"
-              className="w-100 py-2 mb-3 d-flex align-items-center
-                       justify-content-center gap-2 fw-semibold"
-              style={{
-                borderRadius: "0.75rem",
-                boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-              }}
-              onClick={() => setShowMarket(false)}
-            >
-              <span style={{ fontSize: "1.25rem" }}>←</span>
-              퀘스트로 돌아가기
-            </Button>
+            <div className="d-flex gap-2 mb-3">
+              <Button
+                variant="warning"
+                className="inventory-toggle flex-grow-1"
+                onClick={() => setInvOpen(!invOpen)}
+              >
+                <span role="img" aria-label="chest" className="me-1">
+                  📦
+                </span>
+                {invOpen ? "인벤토리 접기" : "내 인벤토리 펼치기"}
+              </Button>
+              <Button
+                variant="secondary"
+                className="flex-grow-1"
+                onClick={() => setShowMarket(false)}
+              >
+                포인트마켓 접기
+              </Button>
+            </div>
 
-            <PurchaseMarket />
+            <PurchaseMarket invOpen={invOpen} setInvOpen={setInvOpen} />
           </Tab>
         </Tabs>
 

--- a/src/components/ParentDashboard.js
+++ b/src/components/ParentDashboard.js
@@ -21,7 +21,7 @@ import ChildRoutineStatus from "./ChildRoutineStatus";
 import ChildPoints from "./ChildPoints";
 import UsageRequests from "./UsageRequests";
 import MarketAdmin from "./MarketAdmin";
-import AfterSchoolSchedule from "./AfterSchoolSchedule";
+import AfterSchoolAdmin from "./AfterSchoolAdmin";
 
 export default function ParentDashboard() {
   /* ───────── 상태 ───────── */
@@ -127,7 +127,7 @@ export default function ParentDashboard() {
 
           {/* 방과후 */}
           <Tab eventKey="afterSchool" title="방과후">
-            <AfterSchoolSchedule />
+            <AfterSchoolAdmin />
           </Tab>
         </Tabs>
       </div>

--- a/src/components/PurchaseMarket.js
+++ b/src/components/PurchaseMarket.js
@@ -17,7 +17,7 @@ import {
 import { Card, Button, Spinner, Form, Collapse, Modal } from "react-bootstrap"; // 🔸 Modal 추가
 import "../styles/PurchaseMarket.css";
 
-export default function PurchaseMarket() {
+export default function PurchaseMarket({ invOpen, setInvOpen }) {
   /* ───────── 상태 ───────── */
   const [inventory, setInventory] = useState([]);
   const [market, setMarket] = useState([]);
@@ -25,7 +25,6 @@ export default function PurchaseMarket() {
   const [selectedParent, setSelectedParent] = useState({}); // txId → parentUid
 
   const [loading, setLoading] = useState(true);
-  const [invOpen, setInvOpen] = useState(false);
 
   /* 🔸 모달용 상태 */
   const [parentModal, setParentModal] = useState(false); // 모달 on/off
@@ -153,18 +152,6 @@ export default function PurchaseMarket() {
   /* ───────── 뷰 ───────── */
   return (
     <>
-      {/* ▣ 인벤토리 토글 ▣ */}
-      <Button
-        variant="warning"
-        className="inventory-toggle mb-3"
-        onClick={() => setInvOpen(!invOpen)}
-      >
-        <span role="img" aria-label="chest" className="me-1">
-          📦
-        </span>
-        {invOpen ? "인벤토리 접기" : "내 인벤토리 펼치기"}
-      </Button>
-
       {/* ▣ 인벤토리 리스트 ▣ */}
       <Collapse in={invOpen}>
         <div className="inventory-list mb-4">
@@ -225,7 +212,7 @@ export default function PurchaseMarket() {
 
       {/* ▣ 패밀리마켓 ▣ */}
       <h5
-        className="mb-3"
+        className="mb-3 text-center"
         style={{
           color: "#A8FF60" /* 글자색 */,
           fontSize: "2rem" /* 폰트 크기 */,

--- a/src/components/RoutineList.js
+++ b/src/components/RoutineList.js
@@ -9,7 +9,6 @@ import {
   updateDoc,
   Timestamp,
   increment,
-  arrayUnion,
 } from "firebase/firestore";
 import { ListGroup, Form, Badge, Spinner } from "react-bootstrap";
 
@@ -19,7 +18,6 @@ const createInitialState = (tasks) => {
     obj[i + 1] = false;
   });
   obj.completedCount = 0;
-  obj.awardedSteps = [];
   return obj;
 };
 
@@ -120,12 +118,11 @@ export default function RoutineList({ session }) {
   // 4) 단계 토글 핸들러
   const toggleStep = async (idx) => {
     if (!uid) return;
-    // 선행 단계가 완료되지 않으면 중지
-    if (idx > 1 && !steps[idx - 1]) return;
 
     // 새 상태 복제
-    const updated = { ...steps, awardedSteps: [...steps.awardedSteps] };
+    const updated = { ...steps };
     updated[idx] = !updated[idx];
+
     // 완료 개수 계산
     const count = TASKS.reduce(
       (acc, _, i) => acc + (updated[i + 1] ? 1 : 0),
@@ -140,16 +137,11 @@ export default function RoutineList({ session }) {
       updatedAt: Timestamp.now(),
     });
 
-    // 포인트 지급 (첫 체크 시 한 번만)
-    if (updated[idx] && !steps.awardedSteps.includes(idx)) {
-      const userRef = doc(db, "users", uid);
-      await updateDoc(userRef, { points: increment(10) });
-      updated.awardedSteps.push(idx);
-      setSteps({ ...updated });
-      await updateDoc(docRef, {
-        [`${session}.awardedSteps`]: arrayUnion(idx),
-      });
-    }
+    // 포인트 변동 (+20 / -20)
+    const userRef = doc(db, "users", uid);
+    await updateDoc(userRef, {
+      points: increment(updated[idx] ? 20 : -20),
+    });
   };
 
   if (!uid) return null;
@@ -169,19 +161,13 @@ export default function RoutineList({ session }) {
             key={i}
             action
             onClick={() => toggleStep(i + 1)}
-            disabled={i > 0 && !steps[i]}
             className="d-flex align-items-center"
-            style={{
-              cursor: i === 0 || steps[i] ? "pointer" : "not-allowed",
-              opacity: i === 0 || steps[i] ? 1 : 0.5,
-            }}
           >
             <Form.Check
               type="checkbox"
               checked={steps[i + 1]}
               onChange={() => toggleStep(i + 1)}
               className="me-2"
-              disabled={i > 0 && !steps[i]}
             />
             <span
               style={{

--- a/src/styles/AfterSchool.css
+++ b/src/styles/AfterSchool.css
@@ -5,6 +5,8 @@
 .after-school td {
   padding: 1rem;
   font-size: 1.25rem;
+  max-width: 4ch;
+  word-break: break-all;
 }
 .after-school .time-col {
   background: var(--bg-main);
@@ -14,4 +16,8 @@
 .after-school .today-col {
   background: #ffd1d1;
   color: inherit;
+}
+
+.after-school .highlight-cell {
+  border: 2px solid red;
 }

--- a/src/styles/PurchaseMarket.css
+++ b/src/styles/PurchaseMarket.css
@@ -5,15 +5,10 @@
 /* ========== 1. 공통 레이아웃 ========== */
 .market-grid {
   display: grid;
-
-  /* 열(트랙) 규칙
-     - 최소 140 px 보다 작아지지 않고
-     - 남는 공간이 있으면 모든 열이 똑같이 넓어지며
-     - 뷰포트가 좁아지면 열 개수가 자동 감소 */
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-
+  grid-template-columns: repeat(2, 1fr);
   gap: 0.6rem;
-  justify-content: center;   /* 마지막 줄을 가운데 정렬 */
+  justify-items: center;
+  justify-content: center;
 }
 
 /* 카드 자체 넓이가 늘어나다 못해 너무 커지는 게 싫다면 +α */


### PR DESCRIPTION
## Summary
- update AddQuest placeholder and default points handling
- shorten weekday headers in After School table and limit text width
- allow routine steps to be completed independently
- tweak child dashboard point market buttons and inventory toggle
- center family market items and show two items per row
- add editable after-school schedule with highlight feature
- enable parents to adjust routine completion with point updates
- deduct or add 20 points whenever routine steps change

## Testing
- `npm test` *(fails: react-scripts not found)*