### PR TITLE
Fix highlight CSS usage in AfterSchool schedule

### DIFF
--- a/src/components/AfterSchoolAdmin.js
+++ b/src/components/AfterSchoolAdmin.js
@@ -86,7 +86,7 @@ export default function AfterSchoolAdmin() {
               <td className="time-col">{t}</td>
               {DAYS.map((d) => {
                 const cell = schedule[d.key][t] || {};
-                const cls = cell.highlight ? "highlight-cell" : "";
+                const cls = cell.highlight ? "highlight" : "";
                 return (
                   <td
                     key={d.key}

--- a/src/components/AfterSchoolSchedule.js
+++ b/src/components/AfterSchoolSchedule.js
@@ -207,7 +207,7 @@ export default function AfterSchoolSchedule({ editable }) {
                     key={`${d}-${t}`}
                     className={`
                       ${d === today ? "today-col" : ""}
-                      ${cellData.highlight ? "highlight table-warning" : ""}
+                      ${cellData.highlight ? "highlight" : ""}
                       ${editable ? "editable-cell" : ""}
                       align-middle
                     `}


### PR DESCRIPTION
## Summary
- fix highlight class in parent after school admin schedule
- remove bootstrap background class so highlighted cells rely on common `.highlight` style

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*